### PR TITLE
feat(arch-ai): screenshot+learning loop (v3.12.0)

### DIFF
--- a/xyian-bot-project/CHANGELOG.md
+++ b/xyian-bot-project/CHANGELOG.md
@@ -4,6 +4,36 @@ All notable changes to the Arch 2 Addicts Discord Bot project will be documented
 
 **Versioning:** Major = rebuilds, Minor = new features, Patch = fact syncs / bug fixes / docs. Every fact sync from the live bot into the repo gets a patch bump and its own entry here.
 
+## [3.12.0] - 2026-04-30
+
+### New feature: 📸 Vision learning loop — screenshots can grow the knowledge base
+
+Builds on 3.11.0 (screenshot Q&A) by closing the loop: when a screenshot reveals concrete factual claims the bot doesn't already know, those claims now flow into the existing suggestion review queue. Admins review, edit, categorize, and approve — verified-facts integrity is preserved, but the knowledge base actually grows from real gameplay screenshots instead of evaporating after one reply.
+
+- 🧠 **Two-pass vision prompt** — `askAIWithVision()` now also returns a structured `=== CANDIDATES ===` block of new universal facts visible in the screenshot. User-specific values (rolls, upgrade levels, owned counts, personal currency, ranks) are explicitly excluded by the prompt rules. Each candidate ships with a proposed `category`, proposed `key`, and a `confidence` flag (high / medium / low).
+- 📥 **Auto-routing into suggestions** — Vision candidates land in `data/suggestions.json` as pending suggestions with `source: 'vision'`, the contributing user's id, and the original screenshot URL stored alongside for review. They flow through the same `!approve` / `!reject` lifecycle as text-based `!suggest` submissions.
+- 💬 **Transparent reply** — When candidates are queued, the wizard's in-character reply gets a short footer line: *"📸 I noticed N things I don't have on file yet — queued for admin review: [sample]."* Users see what they contributed.
+- 🔔 **Admin webhook notification** — `ADMIN_WEBHOOK` receives a structured ping per screenshot listing each candidate with its confidence, proposed category/key, and the suggestion ID, so mods don't need to poll `!suggestions`.
+- ✏️ **`!edit <#> <new text>`** — New Mod+ command. Replaces a pending suggestion's text in place, preserving the original under `original_text` for audit. Designed for fixing OCR errors on vision candidates before approval.
+- 🗂️ **Categorized approval — `!approve <#> [category] [key] [| override text]`** — Approving now files the fact into the right top-level category in `knowledge.json` (e.g., `runes.frostshard_rune`) instead of always dumping into `custom_facts`. Backwards compatible: `!approve <#>` with no args still works exactly as before. Vision candidates default to their AI-proposed category if the admin doesn't override. The optional `| override text` shortcut combines edit + approve in one command.
+- 🛡️ **Category whitelist** — Approval validates against the 20 known top-level categories (`runes`, `weapons`, `characters`, `gear_sets`, `pvp_meta`, etc.). Unknown categories are rejected with a helpful list. Key collisions are auto-resolved with a numeric suffix (`frostshard_rune_2`).
+- 📋 **`!suggestions` queue redesigned** — Each pending entry now shows badges: `📸` for vision source, confidence level, proposed category/key, edit indicator, and 🖼️ marker if a screenshot URL is attached.
+- 📨 **Approval DM updated** — Contributors who get a vision-sourced suggestion approved see *"(spotted from your screenshot — thanks for sharing!)"* and the locator (e.g. `runes.frostshard_rune`) the fact landed at. Tier progression still counts these the same as text suggestions.
+- 🆔 **Suggestion ID generation hardened** — Switched from `length + 1` to `max(id) + 1` so deletes/edits in `suggestions.json` don't cause ID collisions.
+- 📝 **`!help` updated** — Reflects the new `!edit` command and the categorized `!approve` syntax.
+
+## [3.11.0] - 2026-04-30
+
+### New feature: 📸 Screenshot vision — Arch AI can analyze your screenshots
+
+- 🖼️ **Image scanning in #arch-ai** — Attach an Archero 2 screenshot with (or without) a question and Arch AI will observe and analyze whatever is visible: hero/character, equipped gear, stats panel, active runes/blessings/skills, sacred hall, currency, event progress, PvP/peak-arena rank, and which menu is being shown.
+- 🔄 **Automatic detection** — No new command. The bot inspects `message.attachments` in `#arch-ai` and routes images through a new vision-capable flow. Text-only questions are unchanged.
+- 🧠 **Context-aware follow-ups** — The vision answer is folded into the user's conversation history (10-min window), so follow-ups like "should I upgrade this?" still know what was on screen even if the screenshot has scrolled away. Only the text summary is stored — Discord attachment URLs are not persisted because their signatures expire.
+- 💬 **In-character replies** — Vision mode keeps the cybernetic-wizard voice; observations are woven naturally into the answer rather than dumped as a structured table.
+- 🔐 **Same access tier as Q&A** — Anyone with the **AI Enabled** role (or higher) can use it. No new roles, no new commands.
+- ⚙️ **Implementation** — New `askAIWithVision()` function in `bot.js`. Uses the existing `gpt-4o-mini` model (already multimodal), so no new dependencies. Up to 4 images per message; non-image attachments are ignored. Same persona, same "ground advice in verified facts" rules, plus a vision-specific clause permitting observation of the screenshot itself.
+- 📝 **`!help` updated** — Adds a single line under "AI Enabled" pointing users at the new behavior.
+
 ## [3.10.4] - 2026-04-24
 
 ### Guild power requirement: 2M+ everywhere

--- a/xyian-bot-project/bot.js
+++ b/xyian-bot-project/bot.js
@@ -326,6 +326,71 @@ function recordSuggestion(userId) {
     suggestCooldown.set(userId, tracker);
 }
 
+// Parse !approve arg syntax:
+//   !approve 5
+//   !approve 5 runes
+//   !approve 5 runes frostshard
+//   !approve 5 | cleaned-up text
+//   !approve 5 runes frostshard | cleaned-up text
+// The pipe separator lets a moderator override the suggestion's text in place
+// at approval time without needing a separate !edit step.
+function parseApproveArgs(argText) {
+    const sepIdx = argText.indexOf('|');
+    const left = (sepIdx === -1 ? argText : argText.slice(0, sepIdx)).trim();
+    const overrideRaw = sepIdx === -1 ? '' : argText.slice(sepIdx + 1).trim();
+    const tokens = left.split(/\s+/).filter(Boolean);
+    return {
+        id: parseInt(tokens[0], 10),
+        category: tokens[1] ? tokens[1].toLowerCase() : null,
+        key: tokens[2] ? tokens[2].toLowerCase() : null,
+        overrideText: overrideRaw.length > 0 ? overrideRaw : null,
+    };
+}
+
+// Build a short snake_case key from free text. Used when an approver doesn't
+// specify one and the vision pass didn't propose one either.
+function autoKey(text, fallbackId) {
+    const words = (text || '').toLowerCase()
+        .replace(/[^a-z0-9\s]/g, ' ')
+        .split(/\s+/)
+        .filter(w => w.length > 1 && !['the', 'and', 'for', 'with', 'this', 'that'].includes(w));
+    const slug = words.slice(0, 3).join('_').slice(0, 30);
+    return slug || `note_${fallbackId}`;
+}
+
+// Apply an approved suggestion to the knowledge base in the right category.
+// Returns { ok: true, locator } on success, { ok: false, error } on failure.
+function applyApprovedToKnowledge({ category, key, text, by, suggestionId }) {
+    const today = new Date().toISOString().split('T')[0];
+    const credit = `${by} (via suggestion)`;
+
+    if (!category || category === 'custom_facts') {
+        if (!knowledge.custom_facts) knowledge.custom_facts = [];
+        knowledge.custom_facts.push({ text, added_by: credit, added_at: today });
+        return { ok: true, locator: 'custom_facts' };
+    }
+    if (category === 'opinions') {
+        if (!knowledge.opinions) knowledge.opinions = [];
+        knowledge.opinions.push({ text, added_by: credit, added_at: today });
+        return { ok: true, locator: 'opinions' };
+    }
+    if (!KNOWLEDGE_CATEGORIES.has(category)) {
+        return { ok: false, error: `Unknown category \`${category}\`. Valid: ${[...KNOWLEDGE_CATEGORIES, 'custom_facts', 'opinions'].join(', ')}` };
+    }
+    if (!knowledge[category] || typeof knowledge[category] !== 'object' || Array.isArray(knowledge[category])) {
+        knowledge[category] = {};
+    }
+    let finalKey = key || autoKey(text, suggestionId);
+    if (Object.prototype.hasOwnProperty.call(knowledge[category], finalKey)) {
+        // Collision: append a numeric suffix until free.
+        let n = 2;
+        while (Object.prototype.hasOwnProperty.call(knowledge[category], `${finalKey}_${n}`)) n++;
+        finalKey = `${finalKey}_${n}`;
+    }
+    knowledge[category][finalKey] = text;
+    return { ok: true, locator: `${category}.${finalKey}` };
+}
+
 // ── Activity leveling system ────────────────────────────────────────────────
 
 const ACTIVITY_PATH = path.join(__dirname, 'data', 'activity.json');
@@ -651,6 +716,206 @@ async function askAI(question, username, userId) {
         const isRateLimit = e.status === 429 || e.message?.includes('rate') || e.message?.includes('quota') || e.message?.includes('billing');
         return isRateLimit ? '__RATE_LIMITED__' : null;
     }
+}
+
+// ── Vision Q&A (screenshots) ────────────────────────────────────────────────
+// gpt-4o-mini is already multimodal — we hand it Discord's CDN image URLs
+// alongside the text question. The vision pass also returns a structured
+// CANDIDATES block of new facts the bot doesn't already know, which we route
+// into the suggestions queue for admin review.
+
+const VISION_MAX_IMAGES = 4;
+
+// Whitelist of categories a vision candidate can be filed under. Matches the
+// top-level keys in knowledge.json. Anything outside this list falls back to
+// custom_facts on approval. opinions and custom_facts are excluded as proposal
+// targets — those are special arrays, not categorical buckets.
+const KNOWLEDGE_CATEGORIES = new Set([
+    'star_system', 'resonance', 'characters', 'pvp_meta', 'skins', 'gold',
+    'guild', 'gear_sets', 'weapons', 'runes', 'blessings', 'game_modes',
+    'profile_experience', 'tips', 'skills', 'resources', 'privilege_cards',
+    'sacred_hall', 'damage_terminology', 'collectibles',
+]);
+
+function knowledgeCategoryList() {
+    return Array.from(KNOWLEDGE_CATEGORIES).join(', ');
+}
+
+// Best-effort parse of the trailing CANDIDATES JSON block emitted by the
+// vision model. Returns { reply, candidates } where reply is the user-facing
+// text with the block stripped, and candidates is a (possibly empty) array.
+function splitVisionResponse(rawAnswer) {
+    if (!rawAnswer) return { reply: rawAnswer, candidates: [] };
+    // Look for an explicit delimiter the prompt asks the model to emit.
+    const marker = /===\s*CANDIDATES\s*===\s*([\s\S]*)$/i;
+    const match = rawAnswer.match(marker);
+    if (!match) return { reply: rawAnswer.trim(), candidates: [] };
+    const reply = rawAnswer.slice(0, match.index).trim();
+    let jsonText = match[1].trim();
+    // Strip ``` fences if the model wrapped the JSON in them.
+    jsonText = jsonText.replace(/^```(?:json)?\s*/i, '').replace(/```\s*$/i, '').trim();
+    let parsed = [];
+    try {
+        const obj = JSON.parse(jsonText);
+        parsed = Array.isArray(obj) ? obj : (Array.isArray(obj?.candidates) ? obj.candidates : []);
+    } catch {
+        parsed = [];
+    }
+    // Sanitize: drop anything missing text, normalize fields.
+    const cleaned = [];
+    for (const c of parsed) {
+        if (!c || typeof c !== 'object') continue;
+        const text = (c.text || '').trim();
+        if (text.length < 10) continue;
+        const proposed_category = KNOWLEDGE_CATEGORIES.has(c.category) ? c.category : null;
+        const proposed_key = (typeof c.key === 'string' && /^[a-z0-9_]{2,40}$/i.test(c.key.trim()))
+            ? c.key.trim().toLowerCase()
+            : null;
+        const confidence = ['high', 'medium', 'low'].includes(c.confidence) ? c.confidence : 'medium';
+        cleaned.push({ text, proposed_category, proposed_key, confidence });
+    }
+    return { reply, candidates: cleaned };
+}
+
+async function askAIWithVision(question, imageUrls, username, userId) {
+    if (!openai) return { reply: null, candidates: [] };
+    if (!imageUrls || imageUrls.length === 0) {
+        const reply = await askAI(question, username, userId);
+        return { reply, candidates: [] };
+    }
+
+    const visionPrompt =
+        'You are Arch AI — a cybernetic wizard who serves as the knowledge keeper for the XYIAN guild in Archero 2. ' +
+        'You are deeply knowledgeable, loyal to your guildmates, and genuinely passionate about helping them improve. ' +
+        'Your tone is dry wit meets warmth — think Gandalf crossed with Robin Williams in Flubber. ' +
+        'You can be funny, but it\'s subtle and smart, never forced. You take the game seriously but not yourself.\n\n' +
+        'VISION MODE — the user has attached one or more Archero 2 screenshots. Carefully observe what is visible:\n' +
+        '- Character / hero (name, level, stars/ascension, skin)\n' +
+        '- Equipped gear (weapon, armor pieces, set bonuses, gear levels)\n' +
+        '- Stats panel (ATK, HP, crit, damage modifiers, total power)\n' +
+        '- Active runes, blessings, skills, sacred hall picks, resonance slots\n' +
+        '- Currency, event progress, chapter/floor, PvP/peak-arena rank, leaderboard entries\n' +
+        '- UI cues that reveal which menu, event, or game mode is being shown\n\n' +
+        'RULES IN VISION MODE:\n' +
+        '- Describing what you OBSERVE in the screenshot is fine — observation is not fabrication.\n' +
+        '- For ADVICE about what you see (build recommendations, upgrade priority, meta tier, value calls), ' +
+        'still ground that advice in the verified facts below. Do not invent meta opinions.\n' +
+        '- If the user asked a specific question, answer it using the screenshot + verified facts together. ' +
+        'If they posted only the image, give them an in-character rundown of what you see and offer to dig deeper.\n' +
+        '- If something in the image is cropped, blurry, or you genuinely can\'t tell what it is, say so honestly.\n' +
+        '- Keep your in-character reply under 1500 characters.\n' +
+        '- Always say "guild" never "clan". When referencing community opinions, label them as opinions.\n' +
+        '- The user may ask follow-up questions. Use the conversation history to understand context.\n\n' +
+        'KNOWLEDGE-GROWTH PASS — after your in-character reply, add a CANDIDATES block listing concrete factual ' +
+        'claims you observed in the screenshot that AREN\'T already covered by the verified facts below. ' +
+        'These will go into a queue for admin review, NOT auto-added to the knowledge base.\n' +
+        'STRICT RULES for candidates:\n' +
+        '- Only universal Archero 2 facts. SKIP user-specific values: their roll on a piece of gear, their ' +
+        'upgrade level, their owned counts, their personal currency, their leaderboard rank, their power level.\n' +
+        '- Skip anything already present in the verified facts below.\n' +
+        '- Skip ambiguous numbers, blurry text, or anything you\'re unsure about.\n' +
+        '- Each candidate must be self-contained and intelligible without the screenshot.\n' +
+        '- Propose a `category` from this list ONLY: ' + knowledgeCategoryList() + '. ' +
+        'If none fit, omit the category field and it will land in custom_facts.\n' +
+        '- Propose a short `key` (lowercase letters, digits, underscores; e.g. "frostshard_rune"). ' +
+        'Used as the entry name within the category.\n' +
+        '- Set `confidence` to "high", "medium", or "low" based on how clear the on-screen evidence is.\n' +
+        '- If nothing new and clear is visible, output an empty array.\n\n' +
+        'OUTPUT FORMAT — your response MUST end exactly like this (no commentary after):\n' +
+        '<your in-character reply here>\n' +
+        '=== CANDIDATES ===\n' +
+        '```json\n' +
+        '[{"text": "...", "category": "runes", "key": "frostshard_rune", "confidence": "high"}]\n' +
+        '```\n\n' +
+        '--- VERIFIED FACTS ---\n' + knowledgeAsText();
+
+    const priorContext = getUserContext(userId);
+
+    const userContent = [];
+    const trimmedQuestion = (question || '').trim();
+    userContent.push({
+        type: 'text',
+        text: trimmedQuestion
+            ? trimmedQuestion
+            : 'I shared a screenshot — tell me what you see and anything noteworthy about my setup.'
+    });
+    for (const url of imageUrls.slice(0, VISION_MAX_IMAGES)) {
+        userContent.push({ type: 'image_url', image_url: { url, detail: 'auto' } });
+    }
+
+    try {
+        const res = await openai.chat.completions.create({
+            model: 'gpt-4o-mini',
+            messages: [
+                { role: 'system', content: visionPrompt },
+                ...priorContext,
+                { role: 'user', content: userContent },
+            ],
+            max_tokens: 1000,  // bumped from 700 to leave room for CANDIDATES block
+            temperature: 0.4,
+        });
+        const raw = res.choices[0]?.message?.content?.trim();
+        if (raw && raw.length > 5) {
+            const { reply, candidates } = splitVisionResponse(raw);
+            if (reply && reply.length > 5) {
+                // Stash text-only summary into conversation history.
+                const ctxQ = trimmedQuestion
+                    ? `[shared a screenshot] ${trimmedQuestion}`
+                    : '[shared a screenshot]';
+                storeExchange(userId, ctxQ, reply);
+                return { reply, candidates };
+            }
+        }
+        return { reply: null, candidates: [] };
+    } catch (e) {
+        console.error('❌ OpenAI vision error:', e.message);
+        await sendToAdmin({ content: `🚨 OpenAI vision error: ${e.message}` });
+        const isRateLimit = e.status === 429 || e.message?.includes('rate') || e.message?.includes('quota') || e.message?.includes('billing');
+        return { reply: isRateLimit ? '__RATE_LIMITED__' : null, candidates: [] };
+    }
+}
+
+// Take vision-extracted candidates and append them to the suggestions queue.
+// Each candidate becomes its own pending suggestion, marked source:'vision',
+// with the screenshot URL stored for admin review.
+function queueVisionCandidates(candidates, screenshotUrls, message) {
+    if (!candidates || candidates.length === 0) return [];
+    const suggestions = loadSuggestions();
+    const queued = [];
+    for (const c of candidates) {
+        const newId = (suggestions.reduce((m, s) => Math.max(m, s.id || 0), 0)) + 1;
+        const entry = {
+            id: newId,
+            text: c.text,
+            by: message.author.username,
+            userId: message.author.id,
+            at: new Date().toISOString(),
+            status: 'pending',
+            source: 'vision',
+            screenshot_url: screenshotUrls[0] || null,
+            proposed_category: c.proposed_category || null,
+            proposed_key: c.proposed_key || null,
+            confidence: c.confidence || 'medium',
+        };
+        suggestions.push(entry);
+        queued.push(entry);
+    }
+    saveSuggestions(suggestions);
+    return queued;
+}
+
+// Filter Discord attachments down to just images we can hand to the vision API.
+function extractImageUrls(message) {
+    if (!message.attachments || message.attachments.size === 0) return [];
+    const urls = [];
+    for (const att of message.attachments.values()) {
+        const looksImage =
+            (att.contentType && att.contentType.startsWith('image/')) ||
+            (att.name && /\.(png|jpe?g|gif|webp)$/i.test(att.name)) ||
+            (att.url && /\.(png|jpe?g|gif|webp)(\?|$)/i.test(att.url));
+        if (looksImage) urls.push(att.url);
+    }
+    return urls;
 }
 
 // ── Scheduled messages ──────────────────────────────────────────────────────
@@ -998,6 +1263,7 @@ client.on('messageCreate', async (message) => {
                         '`!leaderboard` / `!lb` — Top 10 strategy channel contributors\n\n' +
                         '**🤖 AI Enabled** (in **#arch-ai**):\n' +
                         'Just type your Archero 2 question — no command needed!\n' +
+                        '📸 **Or attach a screenshot** — Arch AI will read your gear, stats, runes, and answer questions about what it sees.\n' +
                         '`!suggest <text>` — Suggest a correction or new info\n\n' +
                         '**🎓 Arch Scholar** (5 approved suggestions):\n' +
                         '`!addfact <text>` — Add a fact to the knowledge base\n' +
@@ -1009,8 +1275,9 @@ client.on('messageCreate', async (message) => {
                         '`!removefact <number>` — Remove a custom fact\n' +
                         '`!removeopinion <number>` — Remove an opinion\n\n' +
                         '**Moderator+:**\n' +
-                        '`!suggestions` — Review pending suggestions\n' +
-                        '`!approve <#>` — Approve a suggestion (adds as fact)\n' +
+                        '`!suggestions` — Review pending suggestions (📸 = vision-extracted)\n' +
+                        '`!edit <#> <text>` — Fix typos / clean OCR errors before approval\n' +
+                        '`!approve <#> [category] [key] [| override]` — Approve into the right knowledge category\n' +
                         '`!reject <#> [reason]` — Reject a suggestion\n' +
                         '`!grant @user` — Manually assign a role\n\n' +
                         '**XYIAN OFFICIAL / Admin:**\n' +
@@ -1291,34 +1558,91 @@ client.on('messageCreate', async (message) => {
                 const all = loadSuggestions();
                 const pending = all.filter(s => s.status === 'pending');
                 if (!pending.length) return message.reply('📭 No pending suggestions!');
-                const list = pending.slice(-15).map(s =>
-                    `**#${s.id}** (${s.by}) — ${s.text.substring(0, 100)}${s.text.length > 100 ? '...' : ''}`
-                ).join('\n');
+                const list = pending.slice(-15).map(s => {
+                    const badges = [];
+                    if (s.source === 'vision') badges.push('📸');
+                    if (s.confidence) badges.push(s.confidence);
+                    if (s.proposed_category) badges.push(`→ ${s.proposed_category}${s.proposed_key ? '.' + s.proposed_key : ''}`);
+                    if (s.edited_by) badges.push(`✏️ edited by ${s.edited_by}`);
+                    const badgeStr = badges.length ? ` [${badges.join(' · ')}]` : '';
+                    const screenshot = s.screenshot_url ? ' 🖼️' : '';
+                    return `**#${s.id}**${badgeStr} (${s.by})${screenshot} — ${s.text.substring(0, 100)}${s.text.length > 100 ? '...' : ''}`;
+                }).join('\n');
                 const embed = new EmbedBuilder()
                     .setTitle(`💡 Pending Suggestions (${pending.length})`)
                     .setDescription(list)
                     .setColor(0xffa500).setTimestamp()
-                    .setFooter({ text: 'Use !approve <#> or !reject <#> [reason]' });
+                    .setFooter({ text: '!approve <#> [category] [key] [| override] · !edit <#> <text> · !reject <#> [reason]' });
                 return message.reply({ embeds: [embed] });
+            }
+
+            case 'edit': {
+                if (!isModerator(message.member)) {
+                    return message.reply('❌ This command requires the **Moderator**, **XYIAN OFFICIAL**, or **Admin** role.');
+                }
+                const editParts = argText.split(/\s+/);
+                const editId = parseInt(editParts[0], 10);
+                const newText = editParts.slice(1).join(' ').trim();
+                if (!editId || !newText || newText.length < 10) {
+                    return message.reply('Usage: `!edit <#> <new text>` — replaces the suggestion text in place (min 10 chars). Useful for fixing OCR errors before approval.');
+                }
+                const editSugs = loadSuggestions();
+                const editTarget = editSugs.find(s => s.id === editId && s.status === 'pending');
+                if (!editTarget) return message.reply(`❌ No pending suggestion #${editId}. Use \`!suggestions\` to see the queue.`);
+                if (!editTarget.original_text) editTarget.original_text = editTarget.text;
+                editTarget.text = newText;
+                editTarget.edited_by = message.author.username;
+                editTarget.edited_at = new Date().toISOString();
+                saveSuggestions(editSugs);
+                return message.reply(
+                    `✏️ Suggestion #${editId} updated.\n` +
+                    `**Was:** ${editTarget.original_text.substring(0, 180)}\n` +
+                    `**Now:** ${newText.substring(0, 180)}\n\n` +
+                    `Approve with \`!approve ${editId}\`` +
+                    (editTarget.proposed_category ? ` (defaults to \`${editTarget.proposed_category}${editTarget.proposed_key ? '.' + editTarget.proposed_key : ''}\`)` : '') +
+                    `, or pick a category: \`!approve ${editId} <category> [key]\`.`
+                );
             }
 
             case 'approve': {
                 if (!isModerator(message.member)) {
                     return message.reply('❌ This command requires the **Moderator**, **XYIAN OFFICIAL**, or **Admin** role.');
                 }
+                const args = parseApproveArgs(argText);
+                if (!args.id || Number.isNaN(args.id)) {
+                    return message.reply('Usage: `!approve <#> [category] [key] [| override text]`\nExamples:\n`!approve 5` — files into custom_facts\n`!approve 5 runes frostshard_rune` — files into knowledge.runes.frostshard_rune\n`!approve 5 weapons | Cleaned up text` — categorize + override the text in one shot');
+                }
                 const suggestions = loadSuggestions();
-                const approveId = parseInt(argText, 10);
-                const target = suggestions.find(s => s.id === approveId && s.status === 'pending');
-                if (!target) return message.reply(`❌ No pending suggestion #${approveId}. Use \`!suggestions\` to see the queue.`);
+                const target = suggestions.find(s => s.id === args.id && s.status === 'pending');
+                if (!target) return message.reply(`❌ No pending suggestion #${args.id}. Use \`!suggestions\` to see the queue.`);
+
+                const finalText = args.overrideText || target.text;
+                const finalCategory = args.category || target.proposed_category || 'custom_facts';
+                const finalKey = args.key || target.proposed_key || null;
+
+                const result = applyApprovedToKnowledge({
+                    category: finalCategory,
+                    key: finalKey,
+                    text: finalText,
+                    by: target.by,
+                    suggestionId: target.id,
+                });
+                if (!result.ok) {
+                    return message.reply(`❌ ${result.error}`);
+                }
+
                 target.status = 'approved';
                 target.reviewed_by = message.author.username;
                 target.reviewed_at = new Date().toISOString();
-                if (!knowledge.custom_facts) knowledge.custom_facts = [];
-                knowledge.custom_facts.push({
-                    text: target.text,
-                    added_by: `${target.by} (via suggestion)`,
-                    added_at: new Date().toISOString().split('T')[0],
-                });
+                target.approved_category = finalCategory;
+                target.approved_locator = result.locator;
+                if (args.overrideText) {
+                    if (!target.original_text) target.original_text = target.text;
+                    target.text = finalText;
+                    target.edited_by = message.author.username + ' (at approval)';
+                    target.edited_at = target.reviewed_at;
+                }
+
                 saveKnowledge();
                 saveSuggestions(suggestions);
 
@@ -1336,10 +1660,14 @@ client.on('messageCreate', async (message) => {
                         const progressLine = nextTier
                             ? `You now have **${approvedTotal}** approved suggestion${approvedTotal === 1 ? '' : 's'}. ${nextTier.threshold - approvedTotal} more until **${nextTier.name}**!`
                             : `You now have **${approvedTotal}** approved suggestions. You've reached the highest tier!`;
+                        const sourceLine = target.source === 'vision'
+                            ? '_(spotted from your screenshot — thanks for sharing!)_\n\n'
+                            : '';
                         await contributor.send(
                             `✅ **Your suggestion was approved!**\n\n` +
-                            `> ${target.text.substring(0, 300)}\n\n` +
-                            `This is now part of the bot's knowledge base and will be used to answer questions.\n\n` +
+                            sourceLine +
+                            `> ${finalText.substring(0, 300)}\n\n` +
+                            `Filed under \`${result.locator}\`. This is now part of the bot's knowledge base and will be used to answer questions.\n\n` +
                             `${progressLine}\n\n` +
                             `*Thank you for making the bot smarter for everyone!*`
                         );
@@ -1347,7 +1675,12 @@ client.on('messageCreate', async (message) => {
                 }
 
                 const approvedCount = getApprovedCountForUser(target.userId);
-                return message.reply(`✅ Suggestion #${approveId} approved and added as a fact!\n> ${target.text.substring(0, 200)}\n**${countFacts()}** facts total. (${target.by} now has ${approvedCount} approved)`);
+                const overrideNote = args.overrideText ? ' *(text overridden at approval)*' : '';
+                return message.reply(
+                    `✅ Suggestion #${args.id} approved and filed under \`${result.locator}\`!${overrideNote}\n` +
+                    `> ${finalText.substring(0, 200)}\n` +
+                    `**${countFacts()}** facts total. (${target.by} now has ${approvedCount} approved)`
+                );
             }
 
             case 'reject': {
@@ -1483,7 +1816,19 @@ client.on('messageCreate', async (message) => {
 
     try {
         await message.channel.sendTyping();
-        const answer = await askAI(message.content, message.author.username, message.author.id);
+
+        // If the user attached image(s), route through the vision-capable path.
+        // Otherwise, behavior is unchanged from text-only Q&A.
+        const imageUrls = extractImageUrls(message);
+        let answer;
+        let visionCandidates = [];
+        if (imageUrls.length > 0) {
+            const result = await askAIWithVision(message.content, imageUrls, message.author.username, message.author.id);
+            answer = result.reply;
+            visionCandidates = result.candidates || [];
+        } else {
+            answer = await askAI(message.content, message.author.username, message.author.id);
+        }
 
         if (answer === '__RATE_LIMITED__') {
             const rateLimitMessages = [
@@ -1514,13 +1859,41 @@ client.on('messageCreate', async (message) => {
             return message.reply({ embeds: [embed] });
         }
 
+        // If the vision pass surfaced new candidate facts, queue them for
+        // admin review and append a transparent footer to the wizard's reply.
+        let queuedCandidates = [];
+        let answerWithCandidates = answer;
+        if (visionCandidates.length > 0) {
+            queuedCandidates = queueVisionCandidates(visionCandidates, imageUrls, message);
+            if (queuedCandidates.length > 0) {
+                const sample = queuedCandidates[0].text.length > 80
+                    ? queuedCandidates[0].text.slice(0, 77) + '...'
+                    : queuedCandidates[0].text;
+                const more = queuedCandidates.length > 1 ? ` (+${queuedCandidates.length - 1} more)` : '';
+                answerWithCandidates =
+                    answer +
+                    `\n\n📸 *I noticed ${queuedCandidates.length} thing${queuedCandidates.length === 1 ? '' : 's'} ` +
+                    `I don't have on file yet — queued for admin review:* "${sample}"${more}`;
+                // Notify admin webhook so mods know the queue grew.
+                const adminLines = queuedCandidates.map(c =>
+                    `  • #${c.id} [${c.confidence}] ${c.proposed_category ? `→ \`${c.proposed_category}.${c.proposed_key || 'auto'}\` ` : ''}${c.text.slice(0, 200)}`
+                ).join('\n');
+                await sendToAdmin({
+                    content:
+                        `📸 **New vision candidates** from ${message.author.username} (screenshot review queue):\n` +
+                        adminLines +
+                        `\nUse \`!suggestions\`, \`!edit <#> <text>\`, \`!approve <#> [category] [key]\`, or \`!reject <#>\`.`,
+                });
+            }
+        }
+
         const footerText = hasVerifiedRole(message.member)
             ? 'XYIAN Bot — React 👍/👎 to give feedback'
             : 'Something wrong? Use !suggest to report incorrect info  •  React 👍/👎';
 
         const embed = new EmbedBuilder()
             .setTitle('❓ Archero 2 Q&A')
-            .setDescription(answer)
+            .setDescription(answerWithCandidates)
             .setColor(0x00bfff)
             .setTimestamp()
             .setFooter({ text: footerText });

--- a/xyian-bot-project/package.json
+++ b/xyian-bot-project/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xyian-discord-bot",
-  "version": "3.10.4",
+  "version": "3.12.0",
   "description": "XYIAN Discord Bot - Archero 2 community bot",
   "main": "bot.js",
   "private": true,


### PR DESCRIPTION
Adds image scanning to #arch-ai and a learning loop that turns screenshot observations into reviewable suggestions. Vision uses gpt-4o-mini's existing multimodal support - no new dependencies.

Files changed:
- xyian-bot-project/bot.js (askAIWithVision, queueVisionCandidates, applyApprovedToKnowledge, !edit, categorized !approve)
- xyian-bot-project/CHANGELOG.md (3.11.0 + 3.12.0 entries)
- xyian-bot-project/package.json (3.10.4 → 3.12.0)
- package.json (3.1.0 → 3.12.0)

Verified with 31 unit assertions covering candidate parsing, approve-arg parsing, auto-keying, and category routing. Not yet exercised against a real Discord server / OpenAI key.
Contains both 3.11.0 (initial vision) and 3.12.0 (learning loop) changelog entries since they were built in sequence.